### PR TITLE
Feature/include launch window in xctrack export

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,8 @@
             "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome against localhost",
-            "file": "${workspaceFolder}/index.html"
+            "url": "http://127.0.0.1:5500",
+            "webRoot": "${workspaceFolder}"
         }
     ]
 }

--- a/js/app/formats/export/xctrack.ejs
+++ b/js/app/formats/export/xctrack.ejs
@@ -16,6 +16,10 @@
        <% } %>
      }<% if (i < turnpoints.length - 1) { %>,<% } %><% } %>
   ],
+  "takeoff":{
+    "timeOpen": "<%- turnpoints[0].open %>:00Z",
+    "timeClose": "<%- turnpoints[0].close %>:00Z"
+  },
   "sss" : {
     "type" : "<%- xcInfo.type.toUpperCase() %>",
     "direction" : "<%- xcInfo.direction.toUpperCase() %>",

--- a/js/app/formats/xctrack.js
+++ b/js/app/formats/xctrack.js
@@ -4,7 +4,7 @@
  **/
 define(['rejs!formats/export/xctrack'], function(exportXCTrack) {
     var date = new Date();
-    var day = date.getUTCDate();
+
     Number.prototype.pad = function(size) {
         var s = String(this);
         while (s.length < (size || 2)) { s = "0" + s; }
@@ -68,9 +68,16 @@ define(['rejs!formats/export/xctrack'], function(exportXCTrack) {
                     tp.type = "turnpoint";
                 }
             }
+            if (tp.type == "takeoff") {
+                tp.open = String(obj.takeoff.timeOpen).replace('"', '').replace(':00Z', '');
+                tp.close = String(obj.takeoff.timeClose).replace('"', '').replace(':00Z', '');
+            }
             if (tp.type == "start") {
-                tp.open = String(obj.sss.timeGates).replace('"', '').replace('Z', '');
+                tp.open = String(obj.sss.timeGates).replace('"', '').replace(':00Z', '');
                 tp.mode = String(obj.sss.direction).toLowerCase();
+            }
+            if (tp.type == "goal") {
+                tp.close = String(obj.goal.deadline).replace('"', '').replace(':00Z', '');
             }
 
             wps.push(wp);;
@@ -85,7 +92,7 @@ define(['rejs!formats/export/xctrack'], function(exportXCTrack) {
 
         return {
             'task': {
-                'date': day.pad(2) + '-' + date.getUTCMonth().pad(2) + '-' + date.getUTCFullYear(),
+                'date': date.getUTCDate().pad(2) + '-' + (date.getUTCMonth() + 1).pad(2) + '-' + date.getUTCFullYear(),
                 'type': 'race-to-goal',
                 'num': 1,
                 'ngates': 1,


### PR DESCRIPTION
The Xctrack export until now does not include the (optional) launch window ("takeoff"). This requires manual adjustments of tasks in FsComp after importing them there. By adding this information in the export file, we ensure that the complete task information is included in the file, and all programs that import it can also set the launch window.

In additiona, the change also allows for complete imports from Xctrack task files, including all the timings.