### PR TITLE
Feature/use local times

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,8 @@
             "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome against localhost",
-            "file": "${workspaceFolder}/index.html"
+            "url": "http://127.0.0.1:5500",
+            "webRoot": "${workspaceFolder}"
         }
     ]
 }

--- a/js/app.js
+++ b/js/app.js
@@ -36,7 +36,8 @@ requirejs.config({
         geographiclib: "../js/lib/geographiclib/geographiclib.min",
         proj4: "../js/lib/proj4/proj4",
         html2canvas: "../js/lib/html2canvas/html2canvas.min",
-        polyline: "../js/app/polyline" // Aggiungi il percorso di polyline
+        polyline: "../js/app/polyline", // Aggiungi il percorso di polyline
+        utils: "../js/utils"
     },
     shim: {
         simplemodal: {

--- a/js/app/filenameList.js
+++ b/js/app/filenameList.js
@@ -27,7 +27,6 @@ define(['jquery'], function($) {
     document.dispatchEvent(e);
   });
 
-
   $(document).on('click', '#clear-task', function(e) {
     var e = document.createEvent("CustomEvent");
     e.initCustomEvent('deleteTask', false, false, {});

--- a/js/app/formats/FsDB.js
+++ b/js/app/formats/FsDB.js
@@ -74,10 +74,8 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter', '
       jsonObj = tasks[taskN - 1];
     }
     
-    
-
     var jumpTheGun = Number(jsonObj.FsScoreFormula._jump_the_gun_max);
-    var turnpointTollerance = Number(jsonObj.FsScoreFormula._turnpoint_radius_tolerance);
+    var turnpointTolerance = Number(jsonObj.FsScoreFormula._turnpoint_radius_tolerance);
 
     var ss = jsonObj.FsTaskDefinition._ss;
     var es = jsonObj.FsTaskDefinition._es;
@@ -149,7 +147,7 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter', '
         'turnpoints': tps,
         'utcOffset': utc_offset,
         'jumpTheGun': jumpTheGun,
-        'turnpointTollerance': turnpointTollerance,
+        'turnpointTolerance': turnpointTolerance,
       },
       'waypoints': wps,
     }

--- a/js/app/formats/FsDB.js
+++ b/js/app/formats/FsDB.js
@@ -11,11 +11,9 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter', '
   }
 
   var x2js = new X2JS();
-
   var jsonDB = null;
-
   var date = new Date();
-  var day = date.getUTCDate();
+
   Number.prototype.pad = function (size) {
     var s = String(this);
     while (s.length < (size || 2)) { s = "0" + s; }
@@ -28,8 +26,6 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter', '
     }
     return false;
   }
-
-
 
   var parse = function (text, filename) {
 
@@ -48,8 +44,7 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter', '
     });
 
     var tasks = jsonDB.Fs.FsCompetition.FsTasks.FsTask;
-
-    var utc_offset = Number(jsonDB.Fs.FsCompetition._utc_offset);
+    var utc_offset = timeUtils.convertUtcOffset(jsonDB.Fs.FsCompetition._utc_offset ?? 0);
 
     var taskN = 0;
     let nt = 1;
@@ -61,9 +56,12 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter', '
       taskN = window.prompt("Tasks in file : " + nt + "\nSelect task number or cancel not to load a task and just load the competition DB", "1");
     }
 
-
     if (isNaN(taskN) || taskN <= 0 || taskN > nt) {
-      return;
+      return {
+        'competition': {
+          'utcOffset': utc_offset,
+        }
+      }  
     }
 
     let jsonObj ;

--- a/js/app/formats/FsDB.js
+++ b/js/app/formats/FsDB.js
@@ -2,7 +2,7 @@
   @file
   Task importer for the task creator.
   **/
-define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], function (exportFsTask, helper, jgrowl, xml_formatter) {
+define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter', 'utils/timeUtils'], function (exportFsTask, helper, jgrowl, xml_formatter, timeUtils) {
 
   Number.prototype.pad = function (size) {
     var s = String(this);
@@ -163,16 +163,9 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], 
       return;
     }
 
-    var UTCOffset = Number(jsonDB.Fs.FsCompetition._utc_offset)
-    if (UTCOffset > 0) {
-      UTCOffset = "+" + UTCOffset.pad(2);
-    }
-    else {
-      UTCOffset = "+" + UTCOffset.pad(2);
-    }
+    var utcOffsetNumber = Number(jsonDB.Fs.FsCompetition._utc_offset)
+    var utcOffset = timeUtils.convertUtcOffset(utcOffsetNumber);
     var FsScoreFormula = x2js.json2xml_str({ FsScoreFormula: jsonDB.Fs.FsCompetition.FsScoreFormula });
-
-
     var tasks = jsonDB.Fs.FsCompetition.FsTasks.FsTask;
     var taskN = 0;
     if (tasks != undefined) {
@@ -196,7 +189,7 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], 
     };
     times.push(time);
 
-    // turnpoints[0] is assumend as Start
+    // turnpoints[1] is assumend as Start
     var time = {
       open: turnpoints[1].open,
       close: turnpoints[turnpoints.length - 1].close
@@ -228,14 +221,13 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], 
       starts.push(h.pad(2) + ":" + m.pad(2))
     }
 
-    //var theDate = date.getUTCFullYear() + '-' + (date.getUTCMonth() + 1).pad(2) + '-' + day.pad(2)
     var theDate = taskInfo.date.substring(6,10) + '-' +  taskInfo.date.substring(3,5) + '-' + taskInfo.date.substring(0,2)
 
     var data = exportFsTask({
       turnpoints: turnpoints,
       taskInfo: taskInfo,
       thedate: theDate,
-      UTCOffset: UTCOffset,
+      UTCOffset: utcOffset,
       times: times,
       FsScoreFormula: FsScoreFormula,
       starts: starts,

--- a/js/app/formats/FsTask.js
+++ b/js/app/formats/FsTask.js
@@ -151,7 +151,7 @@ define(['rejs!formats/export/FsTask'], function (exportFsTask) {
       turnpoints: turnpoints,
       taskInfo: taskInfo,
       thedate: theDate,
-      UTCOffset: '+02',
+      UTCOffset: taskInfo.utcOffset,
       times: times,
       FsScoreFormula: '',
       starts: starts,

--- a/js/app/formats/export/FsTask.ejs
+++ b/js/app/formats/export/FsTask.ejs
@@ -1,11 +1,11 @@
       <FsTask Dirty="1" id="<%- taskID %>" name="Task<%- taskID %>" tracklog_folder="">
         <%- FsScoreFormula %>
         <FsTaskDefinition ss="2" es="<%- es %>" goal="CIRCLE" groundstart="0" qnh_setting="1013.25">
-          <% for (var i = 0; i < turnpoints.length; i++) { %><FsTurnpoint id="<%- turnpoints[i].id %>" lat="<%- turnpoints[i].x %>" lon="<%- turnpoints[i].y %>" altitude="<%- turnpoints[i].z %>" radius="<%- turnpoints[i].radius %>" open="<%- thedate %>T<%- times[i].open %>:00<%- UTCOffset %>:00" close="<%- thedate %>T<%- times[i].close %>:00<%- UTCOffset %>:00" />
+          <% for (var i = 0; i < turnpoints.length; i++) { %><FsTurnpoint id="<%- turnpoints[i].id %>" lat="<%- turnpoints[i].x %>" lon="<%- turnpoints[i].y %>" altitude="<%- turnpoints[i].z %>" radius="<%- turnpoints[i].radius %>" open="<%- thedate %>T<%- times[i].open %>:00<%- UTCOffset %>" close="<%- thedate %>T<%- times[i].close %>:00<%- UTCOffset %>" />
           <% } %> 
-          <% for (var i = 0; i < starts.length; i++) { %><FsStartGate open="<%- thedate %>T<%- starts[i] %>:00<%- UTCOffset %>:00" /> 
+          <% for (var i = 0; i < starts.length; i++) { %><FsStartGate open="<%- thedate %>T<%- starts[i] %>:00<%- UTCOffset %>" /> 
           <% } %>
         </FsTaskDefinition>
-        <FsTaskState task_state="REGULAR" score_back_time="15" cancel_reason="" stop_time="<%- thedate %>T<%- turnpoints[turnpoints.length-1].close %>:00<%- UTCOffset %>:00" />
+        <FsTaskState task_state="REGULAR" score_back_time="15" cancel_reason="" stop_time="<%- thedate %>T<%- turnpoints[turnpoints.length-1].close %>:00<%- UTCOffset %>" />
       </FsTask>
 

--- a/js/app/formats/export/lk8000.ejs
+++ b/js/app/formats/export/lk8000.ejs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lk-task type="Race">
   <options auto-advance="Auto">
-    <time-gate number="<%- taskInfo.ngates %>" open-time="<%- turnpoints[1].open %>"  close-time="<%- turnpoints[1].close %>" interval-time="<%- taskInfo.gateint %>" />
+    <time-gate number="<%- taskInfo.ngates %>" open-time="<%- turnpoints[xcInfo.startIndex].open %>" close-time="<%- turnpoints[xcInfo.goalIndex].close %>" interval-time="<%- taskInfo.gateint %>" />
     <rules>
       <finish fai-height="true" min-height="0" />
       <start max-height="0" max-height-margin="0" max-speed="69444" max-speed-margin="13889" height-ref="AGL" />

--- a/js/app/formats/export/tsk.ejs
+++ b/js/app/formats/export/tsk.ejs
@@ -3,14 +3,14 @@
   <rte>
     <date><%- taskInfo.date %></date>
     <utcoffset><%- taskInfo.utcOffset %></utcoffset>
-    <date><%- taskInfo.date %></date>
+    <type><%- taskInfo.date %></type>
     <num><%- taskInfo.num %></num>
     <ngates><%- taskInfo.ngates %></ngates>
     <gateint><%- taskInfo.gateint %></gateint>
     <info><%- taskInfo.info %></info>
     <% for (var i = 0; i < turnpoints.length; i++) { %>
       <rtept lon="<%- turnpoints[i].y %>" lat="<%- turnpoints[i].x %>">
-        <close><%- timeUtils.localToUtc(turnpoints[i].close, taskInfo.utcOffset) %></close>
+        <close><%- turnpoints[i].close %></close>
         <!-- <filename>task_<%- taskInfo.date %>.tsk</filename> -->
         <fileOrigin><%- turnpoints[i].filename %></fileOrigin>
         <goalType><%- turnpoints[i].goalType %></goalType>
@@ -18,7 +18,7 @@
         <index><%- turnpoints[i].index %></index>
         <mode><%- turnpoints[i].mode %></mode>
         <name><%- turnpoints[i].name %></name>
-        <open><%- timeUtils.localToUtc(turnpoints[i].open, taskInfo.utcOffset) %></open>
+        <open><%- turnpoints[i].open %></open>
         <radius><%- turnpoints[i].radius %></radius>
         <type><%- turnpoints[i].type %></type>
         <z><%- turnpoints[i].z %></z>

--- a/js/app/formats/export/tsk.ejs
+++ b/js/app/formats/export/tsk.ejs
@@ -2,14 +2,15 @@
 <gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Task Planner">
   <rte>
     <date><%- taskInfo.date %></date>
-    <type><%- taskInfo.type %></type>
+    <utcoffset><%- taskInfo.utcOffset %></utcoffset>
+    <date><%- taskInfo.date %></date>
     <num><%- taskInfo.num %></num>
     <ngates><%- taskInfo.ngates %></ngates>
     <gateint><%- taskInfo.gateint %></gateint>
     <info><%- taskInfo.info %></info>
     <% for (var i = 0; i < turnpoints.length; i++) { %>
       <rtept lon="<%- turnpoints[i].y %>" lat="<%- turnpoints[i].x %>">
-        <close><%- turnpoints[i].close %></close>
+        <close><%- timeUtils.localToUtc(turnpoints[i].close, taskInfo.utcOffset) %></close>
         <!-- <filename>task_<%- taskInfo.date %>.tsk</filename> -->
         <fileOrigin><%- turnpoints[i].filename %></fileOrigin>
         <goalType><%- turnpoints[i].goalType %></goalType>
@@ -17,7 +18,7 @@
         <index><%- turnpoints[i].index %></index>
         <mode><%- turnpoints[i].mode %></mode>
         <name><%- turnpoints[i].name %></name>
-        <open><%- turnpoints[i].open %></open>
+        <open><%- timeUtils.localToUtc(turnpoints[i].open, taskInfo.utcOffset) %></open>
         <radius><%- turnpoints[i].radius %></radius>
         <type><%- turnpoints[i].type %></type>
         <z><%- turnpoints[i].z %></z>

--- a/js/app/formats/export/xctrack.ejs
+++ b/js/app/formats/export/xctrack.ejs
@@ -27,6 +27,6 @@
   },  
   "goal" : {
     "type" : "<%- xcInfo.goalType.toUpperCase() %>",
-    "deadline": "<%- xcInfo.deadline %>",
+    "deadline": "<%- xcInfo.deadline %>"
   }
 }

--- a/js/app/formats/export/xctrack.ejs
+++ b/js/app/formats/export/xctrack.ejs
@@ -17,16 +17,16 @@
      }<% if (i < turnpoints.length - 1) { %>,<% } %><% } %>
   ],
   "takeoff":{
-    "timeOpen": "<%- turnpoints[0].open %>:00Z",
-    "timeClose": "<%- turnpoints[0].close %>:00Z"
+    "timeOpen": "<%- timeUtils.localToUtc(turnpoints[0].open, taskInfo.utcOffset) %>:00Z",
+    "timeClose": "<%- timeUtils.localToUtc(turnpoints[0].close, taskInfo.utcOffset) %>:00Z"
   },
   "sss" : {
     "type" : "<%- xcInfo.type.toUpperCase() %>",
     "direction" : "<%- xcInfo.direction.toUpperCase() %>",
-    "timeGates" : ["<%- xcInfo.timeGates %>:00Z"]
+    "timeGates" : <%- JSON.stringify(xcInfo.timeGates) %>
   },  
   "goal" : {
     "type" : "<%- xcInfo.goalType.toUpperCase() %>",
-    "deadline" : "<%- xcInfo.deadline %>:00Z"
+    "deadline": "<%- xcInfo.deadline %>",
   }
 }

--- a/js/app/formats/lk8000.js
+++ b/js/app/formats/lk8000.js
@@ -74,10 +74,23 @@ define(['rejs!formats/export/lk8000'], function(exportTSK) {
   }
   
   var exporter = function(turnpoints, taskInfo) {
+    var xcInfo = {};
+    for (var i = 0; i < turnpoints.length; i++) {
+        if (turnpoints[i].type == "start") {
+          xcInfo.startIndex = i;
+        }
+
+        if (turnpoints[i].type == "goal") {
+          xcInfo.goalIndex = i;
+        }
+    }
+        
     var data = exportTSK({
       turnpoints : turnpoints,
-      taskInfo : taskInfo
+      taskInfo : taskInfo,
+      xcInfo : xcInfo,
     });
+
     return new Blob([data], {'type': "text/xml"});
   }
 

--- a/js/app/formats/tsk.js
+++ b/js/app/formats/tsk.js
@@ -2,7 +2,7 @@
   @file
   Task importer for the task creator.
   **/
-define(['rejs!formats/export/tsk'], function(exportTSK) {
+define(['rejs!formats/export/tsk', 'utils/timeUtils'], function(exportTSK, timeUtils) {
   var check = function(text, filename) {
     if (filename.split('.').pop() == 'tsk') {
       return true;
@@ -88,7 +88,8 @@ define(['rejs!formats/export/tsk'], function(exportTSK) {
   var exporter = function(turnpoints, taskInfo) {
     var data = exportTSK({
       turnpoints : turnpoints,
-      taskInfo : taskInfo
+      taskInfo : taskInfo,
+      timeUtils : timeUtils,
     });
     return new Blob([data], {'type': "text/xml"});
   }

--- a/js/app/formats/tsk.js
+++ b/js/app/formats/tsk.js
@@ -70,7 +70,7 @@ define(['rejs!formats/export/tsk', 'utils/timeUtils'], function(exportTSK, timeU
     }
    
     var utcOffset = xmlDoc.getElementsByTagName('utcoffset').childNode? xmlDoc.getElementsByTagName('utcoffset').childNodes[0].nodeValue 
-      : timeUtils.utcOffsets[timeUtils.utcZeroIndex];
+      : timeUtils.getLocalOffset();
 
     return {
       'task' : {

--- a/js/app/formats/tsk.js
+++ b/js/app/formats/tsk.js
@@ -69,7 +69,8 @@ define(['rejs!formats/export/tsk', 'utils/timeUtils'], function(exportTSK, timeU
       } 
     }
    
-
+    var utcOffset = xmlDoc.getElementsByTagName('utcoffset').childNode? xmlDoc.getElementsByTagName('utcoffset').childNodes[0].nodeValue 
+      : timeUtils.utcOffsets[timeUtils.utcZeroIndex];
 
     return {
       'task' : {
@@ -78,6 +79,7 @@ define(['rejs!formats/export/tsk', 'utils/timeUtils'], function(exportTSK, timeU
         'num' : xmlDoc.getElementsByTagName('num')[0].childNodes[0].nodeValue,
         'ngates' : xmlDoc.getElementsByTagName('ngates')[0].childNodes[0].nodeValue,
         'gateint' : xmlDoc.getElementsByTagName('gateint')[0].childNodes[0].nodeValue,
+        'utcOffset' : utcOffset,
         'info' : tinfo,
         'turnpoints' : tps,
       },
@@ -89,7 +91,6 @@ define(['rejs!formats/export/tsk', 'utils/timeUtils'], function(exportTSK, timeU
     var data = exportTSK({
       turnpoints : turnpoints,
       taskInfo : taskInfo,
-      timeUtils : timeUtils,
     });
     return new Blob([data], {'type': "text/xml"});
   }

--- a/js/app/param.js
+++ b/js/app/param.js
@@ -49,7 +49,7 @@ define(['utils/timeUtils'], function (timeUtils) {
         compInfo: "",
         utcOffset: timeUtils.getLocalOffset(),
         jumpTheGun: 0,
-        turnpointTollerance: 0,
+        turnpointTolerance: 0,
       }
     },
     turnpoint: {

--- a/js/app/param.js
+++ b/js/app/param.js
@@ -47,7 +47,7 @@ define(['utils/timeUtils'], function (timeUtils) {
         gateint: 15,
         info: "",
         compInfo: "",
-        utcOffset: timeUtils.utcOffsets[timeUtils.utcZeroIndex],
+        utcOffset: timeUtils.getLocalOffset(),
         jumpTheGun: 0,
         turnpointTollerance: 0,
       }

--- a/js/app/param.js
+++ b/js/app/param.js
@@ -2,7 +2,7 @@
  * @file
  * Param module for the task creator.
  */
-define([], function () {
+define(['utils/timeUtils'], function (timeUtils) {
 
   Number.prototype.pad = function (size) {
     var s = String(this);
@@ -47,7 +47,7 @@ define([], function () {
         gateint: 15,
         info: "",
         compInfo: "",
-        utcOffset: 2,
+        utcOffset: timeUtils.utcOffsets[timeUtils.utcZeroIndex],
         jumpTheGun: 0,
         turnpointTollerance: 0,
       }

--- a/js/app/task/fullBoard.js
+++ b/js/app/task/fullBoard.js
@@ -145,11 +145,11 @@ define(['jquery', 'app/helper', 'app/param', 'html2canvas', 'rejs!task/templates
           taskInfo: taskInfo
         }));
 
-        var g = "";
-        if (taskInfo.ngates > 1) {
-          g = " Gates: " + taskInfo.ngates + "  +" + taskInfo.gateint + "m";
-        }
         if (type == 'start') {
+          var g = "";
+          if (taskInfo.ngates > 1) {
+            g = ", " + taskInfo.ngates + " gates, +" + taskInfo.gateint + " minutes";
+          }
           $("#fullboard-" + type + "-open").html(turnpoints[i].open + g);
         }
 

--- a/js/app/task/task.js
+++ b/js/app/task/task.js
@@ -188,6 +188,11 @@ define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2',
       taskChange(); // Trigger task change event
     };
 
+    var onSetUtcOffset = function (e) {
+      taskInfo.utcOffset = e.detail.utcOffset;
+      taskChange(); // Trigger task change event
+    }
+
     var onTaskChanged= function (e) {
       taskChange();
     }
@@ -265,6 +270,7 @@ define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2',
     document.addEventListener('changeTaskInfo', onchangeTaskInfo);
     document.addEventListener('changeCompInfo', onchangeCompInfo);
     document.addEventListener('changeUtcOffset', onChangeUtcOffset);
+    document.addEventListener('setUtcOffset', onSetUtcOffset);
 
     document.addEventListener('taskChanged', onTaskChanged);
     document.addEventListener('openTaskFullBoard2', onOpenTaskFullBoard2);

--- a/js/app/task/task.js
+++ b/js/app/task/task.js
@@ -175,7 +175,7 @@ define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2',
     
     var onChangeUtcOffset = function (e) {
       var forward = e.detail.forward;
-      index = timeUtils.utcOffsets.indexOf(taskInfo.utcOffset);
+      var index = timeUtils.utcOffsets.indexOf(taskInfo.utcOffset);
       if (index == -1) {
         index = timeUtils.utcZeroIndex; // Default to UTC+0 if not found
       }

--- a/js/app/task/task.js
+++ b/js/app/task/task.js
@@ -2,8 +2,8 @@
  * @file
  * Task Module for the task creator.
  */
-define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2', 'app/param', 'task/taskOptimiser', 'task/taskAdvisor', 'task/taskExporter'],
-  function (taskBoard, Turnpoint, fullBoard, fullBoard2 , param, optimizer, taskAdvisor, taskExporter) {
+define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2', 'app/param', 'task/taskOptimiser', 'task/taskAdvisor', 'task/taskExporter', 'utils/timeUtils'],
+  function (taskBoard, Turnpoint, fullBoard, fullBoard2 , param, optimizer, taskAdvisor, taskExporter, timeUtils) {
     var turnpoints = [];
     var taskInfo = param.task.default;
     taskInfo.id = 0;
@@ -15,8 +15,6 @@ define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2',
     if (taskInformation != null) {
       param.task.default.compInfo = taskInformation;
     }
-
- 
 
     var addTurnpoint = function (waypoint, turnpointInfo) {
       var turnpoint = new Turnpoint(waypoint);
@@ -175,8 +173,20 @@ define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2',
       localStorage.setItem('taskInformation', info);
     }
     
-
-
+    var onChangeUtcOffset = function (e) {
+      var forward = e.detail.forward;
+      index = timeUtils.utcOffsets.indexOf(taskInfo.utcOffset);
+      if (index == -1) {
+        index = timeUtils.utcZeroIndex; // Default to UTC+0 if not found
+      }
+      if (forward) {
+        index = (index + 1) % timeUtils.utcOffsets.length;
+      } else {
+        index = (index - 1 + timeUtils.utcOffsets.length) % timeUtils.utcOffsets.length;
+      }
+      taskInfo.utcOffset = timeUtils.utcOffsets[index];
+      taskChange(); // Trigger task change event
+    };
 
     var onTaskChanged= function (e) {
       taskChange();
@@ -254,6 +264,7 @@ define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2',
     document.addEventListener('changeTaskDate', onchangeTaskDate);
     document.addEventListener('changeTaskInfo', onchangeTaskInfo);
     document.addEventListener('changeCompInfo', onchangeCompInfo);
+    document.addEventListener('changeUtcOffset', onChangeUtcOffset);
 
     document.addEventListener('taskChanged', onTaskChanged);
     document.addEventListener('openTaskFullBoard2', onOpenTaskFullBoard2);

--- a/js/app/task/taskBoard.js
+++ b/js/app/task/taskBoard.js
@@ -13,8 +13,6 @@ define(['rejs!task/templates/taskboard', 'app/param', 'jquery', 'jquery-ui'], fu
     document.dispatchEvent(e);
   });
 
-
-
   $(document).on('click', '#increase-task', function (e) {
     var e = document.createEvent("CustomEvent");
     e.initCustomEvent('changeTaskNumber', false, false, {
@@ -22,16 +20,6 @@ define(['rejs!task/templates/taskboard', 'app/param', 'jquery', 'jquery-ui'], fu
     });
     document.dispatchEvent(e);
   });
-
-
-
-
-  $(document).on('click', '#toggle-turn', function (e) {
-    var e = document.createEvent("CustomEvent");
-    e.initCustomEvent('changeTaskTurn', false, false, {});
-    document.dispatchEvent(e);
-  });
-
 
   $(document).on('click', '#decrease-task', function (e) {
     var e = document.createEvent("CustomEvent");
@@ -41,8 +29,27 @@ define(['rejs!task/templates/taskboard', 'app/param', 'jquery', 'jquery-ui'], fu
     document.dispatchEvent(e);
   });
 
+  $(document).on('click', '#toggle-turn', function (e) {
+    var e = document.createEvent("CustomEvent");
+    e.initCustomEvent('changeTaskTurn', false, false, {});
+    document.dispatchEvent(e);
+  });
 
+  $(document).on('click', '#increase-utc-offset', function (e) {
+    var e = document.createEvent("CustomEvent");
+    e.initCustomEvent('changeUtcOffset', false, false, {
+      forward: true,
+    });
+    document.dispatchEvent(e);
+  });
 
+  $(document).on('click', '#decrease-utc-offset', function (e) {
+    var e = document.createEvent("CustomEvent");
+    e.initCustomEvent('changeUtcOffset', false, false, {
+      forward: false,
+    });
+    document.dispatchEvent(e);
+  });
 
   // $(document).on('click', '#change_task_date', function(e) {
   //   $( "#change_task_date" ).datepicker({

--- a/js/app/task/templates/taskboard.ejs
+++ b/js/app/task/templates/taskboard.ejs
@@ -48,7 +48,13 @@
         style="background-color : #383838 ;font-size: 1.0em; padding : 2px;">Turn :
         <%- taskInfo.turn %></span>
       <button id="toggle-turn" class="btn btn-primary btn-xs pull-right">T</button>
+    </div>
 
+    <div style="padding : 3px;"> <span class="label label-default"
+        style="background-color : #383838 ;font-size: 1.0em; padding : 2px;">UTC offset :
+        <%- taskInfo.utcOffset %>
+      <button id="increase-utc-offset" class="btn btn-primary btn-xs pull-right">+</button>
+      <button id="decrease-utc-offset" class="btn btn-primary btn-xs pull-right">-</button>
     </div>
 
     <div style="padding : 3px;"> <span class="label label-default"

--- a/js/app/task/templates/taskboard.ejs
+++ b/js/app/task/templates/taskboard.ejs
@@ -64,8 +64,7 @@
         style="background-color : #204d74 ;font-size: 1.0em; padding : 2px;">Window close : <%- windows_close %></span>
     </div>
     <div style="padding : 3px;"> <span class="label label-default"
-        style="background-color : #ac2925 ;font-size: 1.0em; padding : 2px;">Start : <%- start_open %>
-        <% if ( taskInfo.ngates > 1 ) { %> Gates:<%- taskInfo.ngates %> +<%- taskInfo.gateint %> Minutes<% 	} %> </span>
+        style="background-color : #ac2925 ;font-size: 1.0em; padding : 2px;">Start : <%- start_open %><% if ( taskInfo.ngates > 1 ) { %>, <%- taskInfo.ngates %> gates, +<%- taskInfo.gateint %> Minutes<% 	} %> </span>
     </div>
     <div style="padding : 3px;"> <span class="label label-default"
       style="background-color : #398439 ;font-size: 1.0em; padding : 2px;">Task deadline : <%- deadline %></span>

--- a/js/app/tracks/track.js
+++ b/js/app/tracks/track.js
@@ -158,8 +158,8 @@ define(['app/helper', 'app/param', 'task/task', 'app/geoCalc', 'app/map', 'jquer
 
           const d1 = geoCalc.computeDistanceBetween(turnpoints[itp].x, turnpoints[itp].y, this.points[ip].x, this.points[ip].y);
           const d2 = geoCalc.computeDistanceBetween(turnpoints[itp].x, turnpoints[itp].y, this.points[ip + 1].x, this.points[ip + 1].y);
-          const RL = turnpoints[itp].radius - Math.max(turnpoints[itp].radius * taskInfo.turnpointTollerance, 5);
-          const RG = turnpoints[itp].radius + Math.max(turnpoints[itp].radius * taskInfo.turnpointTollerance, 5);
+          const RL = turnpoints[itp].radius - Math.max(turnpoints[itp].radius * taskInfo.turnpointTolerance, 5);
+          const RG = turnpoints[itp].radius + Math.max(turnpoints[itp].radius * taskInfo.turnpointTolerance, 5);
 
           if ((RL <= d1 && d1 <= RG) || (RL <= d2 && d2 <= RG) || (d1 < RL && d2 > RG) || (d2 < RL && d1 > RG)) {
             const seconds = this.igcToSeconds(this.points[ip].time, taskInfo);

--- a/js/app/uploader.js
+++ b/js/app/uploader.js
@@ -50,6 +50,13 @@ define(['Dropzone', 'app/wpParser', 'jquery'], function(Dropzone, wpParser, $) {
       document.dispatchEvent(e); 
     }
 
+    if (parseInfo.competition) {
+      var e = document.createEvent("CustomEvent");
+      e.initCustomEvent('setUtcOffset', false, false, {
+        utcOffset : parseInfo.competition.utcOffset,
+      });
+      document.dispatchEvent(e); 
+    }
   }
 
   reader.onload = function(e) {

--- a/js/app/wpParser.js
+++ b/js/app/wpParser.js
@@ -81,6 +81,10 @@ define(['jquery', 'waypoints/waypoints', 'task/task', 'tracks/tracks', 'formats/
                 }
             }
 
+            if (fileInfo.competition) {
+                parseInfo.competition = fileInfo.competition;
+            }
+
             if (fileInfo.KmlLayer) {
                 parseInfo.KmlLayer = fileInfo.KmlLayer;
             }

--- a/js/utils/timeUtils.js
+++ b/js/utils/timeUtils.js
@@ -83,10 +83,22 @@ define(function () {
         return `${localHour.toString().padStart(2, '0')}:${localMinute.toString().padStart(2, '0')}`;
     }
 
+    var addMinutes = function (time, minutes) {
+        // time: "14:09"
+        // minutes: 30
+        const [hour, minute] = time.split(':').map(Number);
+        let totalMinutes = hour * 60 + minute + minutes;
+        totalMinutes = (totalMinutes + 24 * 60) % (24 * 60); // Wrap around if it exceeds 24 hours
+        const newHour = Math.floor(totalMinutes / 60);
+        const newMinute = totalMinutes % 60;
+        return `${newHour.toString().padStart(2, '0')}:${newMinute.toString().padStart(2, '0')}`;
+    }
+
     return {
         utcOffsets: utcOffsets,
         utcZeroIndex: utcZeroIndex,
         localToUtc: localToUtc,
-        utcToLocal: utcToLocal
+        utcToLocal: utcToLocal,
+        addMinutes: addMinutes
     }
 });

--- a/js/utils/timeUtils.js
+++ b/js/utils/timeUtils.js
@@ -120,6 +120,15 @@ define(function () {
         return (localOffset < 0 ? "+" : "-") + String(hours).padStart(2, '0') + ":" + String(minutes).padStart(2, '0');
     }
 
+    var getTimeDifference = function (time1, time2) {
+        // time1, time2: "HH:MM"
+        const [hour1, minute1] = time1.split(':').map(Number);
+        const [hour2, minute2] = time2.split(':').map(Number);
+        const totalMinutes1 = hour1 * 60 + minute1;
+        const totalMinutes2 = hour2 * 60 + minute2;
+        return Math.abs(totalMinutes1 - totalMinutes2);
+    }
+
     return {
         utcOffsets: utcOffsets,
         utcZeroIndex: utcZeroIndex,
@@ -128,5 +137,6 @@ define(function () {
         addMinutes: addMinutes,
         convertUtcOffset: convertUtcOffset,
         getLocalOffset: getLocalOffset,
+        getTimeDifference: getTimeDifference,
     }
 });

--- a/js/utils/timeUtils.js
+++ b/js/utils/timeUtils.js
@@ -110,12 +110,23 @@ define(function () {
         return `${sign}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
     }
 
+    var getLocalOffset = function () {
+        // Get the local timezone offset in minutes
+        const localOffset = new Date().getTimezoneOffset();
+        // Convert to hours and minutes
+        const hours = Math.floor(Math.abs(localOffset) / 60);
+        const minutes = Math.abs(localOffset) % 60;
+        // Format as "+HH:MM" or "-HH:MM"
+        return (localOffset < 0 ? "+" : "-") + String(hours).padStart(2, '0') + ":" + String(minutes).padStart(2, '0');
+    }
+
     return {
         utcOffsets: utcOffsets,
         utcZeroIndex: utcZeroIndex,
         localToUtc: localToUtc,
         utcToLocal: utcToLocal,
         addMinutes: addMinutes,
-        convertUtcOffset: convertUtcOffset
+        convertUtcOffset: convertUtcOffset,
+        getLocalOffset: getLocalOffset,
     }
 });

--- a/js/utils/timeUtils.js
+++ b/js/utils/timeUtils.js
@@ -1,0 +1,92 @@
+define(function () {
+    const utcOffsets = [
+        "-12:00",
+        "-11:00",
+        "-10:00",
+        "-09:30",
+        "-09:00",
+        "-08:00",
+        "-07:00",
+        "-06:00",
+        "-05:00",
+        "-04:30",
+        "-04:00",
+        "-03:30",
+        "-03:00",
+        "-02:30",
+        "-02:00",
+        "-01:00",
+        "+00:00",
+        "+01:00",
+        "+02:00",
+        "+03:00",
+        "+03:30",
+        "+04:00",
+        "+04:30",
+        "+05:00",
+        "+05:30",
+        "+05:45",
+        "+06:00",
+        "+06:30",
+        "+07:00",
+        "+08:00",
+        "+08:45",
+        "+09:00",
+        "+09:30",
+        "+10:00",
+        "+10:30",
+        "+11:00",
+        "+12:00",
+        "+12:45",
+        "+13:00",
+        "+13:45",
+        "+14:00"
+    ];
+    
+    const utcZeroIndex = utcOffsets.indexOf("+00:00");
+
+    var parseTime = function (time) {
+        // Parses a time string, with optional leading '+' or '-' (e.g., "+02:00" or "12:30") into total minutes
+        sign = 1;
+        index = 0;
+        if (time.startsWith('+') || time.startsWith('-')) {
+            sign = time[0] === '-' ? -1 : 1;
+            index = 1;
+        }
+
+        const [hour, minute] = time.slice(index).split(':').map(Number);
+        return sign * (hour * 60 + minute);
+    }
+
+    var localToUtc = function (localTime, utcOffset) {
+        // localTime: "14:09"
+        // utcOffset: "+02:00" or "-05:30"
+        const localTotalMinutes = parseTime(localTime);
+        const offsetTotalMinutes = parseTime(utcOffset);
+        let utcTotalMinutes = localTotalMinutes - offsetTotalMinutes;
+        utcTotalMinutes = (utcTotalMinutes + 24 * 60) % (24 * 60);
+        const utcHour = Math.floor(utcTotalMinutes / 60);
+        const utcMinute = utcTotalMinutes % 60;
+        return `${utcHour.toString().padStart(2, '0')}:${utcMinute.toString().padStart(2, '0')}`;        
+    }
+
+    var utcToLocal = function (utcTime, utcOffset) {
+        // utcTime: "14:09"
+        // utcOffset: "+02:00" or "-05:30"
+        const utcTotalMinutes = parseTime(utcTime);
+        const offsetTotalMinutes = parseTime(utcOffset);
+        // Add the offset to the UTC time to get local time
+        let localTotalMinutes = utcTotalMinutes + offsetTotalMinutes;
+        localTotalMinutes = (localTotalMinutes + 24 * 60) % (24 * 60);
+        const localHour = Math.floor(localTotalMinutes / 60);
+        const localMinute = localTotalMinutes % 60;
+        return `${localHour.toString().padStart(2, '0')}:${localMinute.toString().padStart(2, '0')}`;
+    }
+
+    return {
+        utcOffsets: utcOffsets,
+        utcZeroIndex: utcZeroIndex,
+        localToUtc: localToUtc,
+        utcToLocal: utcToLocal
+    }
+});

--- a/js/utils/timeUtils.js
+++ b/js/utils/timeUtils.js
@@ -94,11 +94,28 @@ define(function () {
         return `${newHour.toString().padStart(2, '0')}:${newMinute.toString().padStart(2, '0')}`;
     }
 
+    var convertUtcOffset = function(offset) {
+        // Parse the offset as a float
+        const offsetFloat = parseFloat(offset);
+    
+        // Determine the sign and absolute value
+        const sign = offsetFloat >= 0 ? "+" : "-";
+        const absoluteOffset = Math.abs(offsetFloat);
+    
+        // Extract hours and minutes
+        const hours = Math.floor(absoluteOffset);
+        const minutes = Math.round((absoluteOffset - hours) * 60);
+    
+        // Format the result as HH:MM with the sign
+        return `${sign}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+    }
+
     return {
         utcOffsets: utcOffsets,
         utcZeroIndex: utcZeroIndex,
         localToUtc: localToUtc,
         utcToLocal: utcToLocal,
-        addMinutes: addMinutes
+        addMinutes: addMinutes,
+        convertUtcOffset: convertUtcOffset
     }
 });


### PR DESCRIPTION
Until now it is unclear whether the task times are in UTC or local time (and if local time, what is the UTC offset). In some cases the UTC offset is hardcoded to 2 hours. When exporting to Xctrack, the shown times are used as UTC times, which can be confusing to pilots.

To remedy all that, there is now a new parameter "utcOffset" on taskInfo. All times shown in the UI are local times, which are then converted into UTC times as required for exports. Conversely, the imports convert the times, using the local machine's UTC offset if none is given in the imported file.