### PR TITLE
Fix/turn direction based on date

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,8 @@
             "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome against localhost",
-            "file": "${workspaceFolder}/index.html"
+            "url": "http://127.0.0.1:5500",
+            "webRoot": "${workspaceFolder}"
         }
     ]
 }

--- a/js/app/formats/FsDB.js
+++ b/js/app/formats/FsDB.js
@@ -2,7 +2,7 @@
   @file
   Task importer for the task creator.
   **/
-define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], function (exportFsTask, helper, jgrowl, xml_formatter) {
+define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter', 'formats/FsTask'], function (exportFsTask, helper, jgrowl, xml_formatter, FsTask) {
 
   Number.prototype.pad = function (size) {
     var s = String(this);
@@ -55,7 +55,7 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], 
     let nt = 1;
 
     if (tasks != undefined) {
-      if ( tasks.length != undefined) {
+      if (tasks.length != undefined) {
         nt = tasks.length;
       }
       taskN = window.prompt("Tasks in file : " + nt + "\nSelect task number or cancel not to load a task and just load the competition DB", "1");
@@ -66,93 +66,22 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], 
       return;
     }
 
-    let jsonObj ;
-    if ( nt ==1 ) {
-      jsonObj = tasks;
+    let jsonObj;
+    if (nt == 1) {
+      jsonObj = { FsTask: tasks };
     }
     else {
-      jsonObj = tasks[taskN - 1];
-    }
-    
-    
-
-    var jumpTheGun = Number(jsonObj.FsScoreFormula._jump_the_gun_max);
-    var turnpointTollerance = Number(jsonObj.FsScoreFormula._turnpoint_radius_tolerance);
-
-    var ss = jsonObj.FsTaskDefinition._ss;
-    var es = jsonObj.FsTaskDefinition._es;
-    var stop_time = jsonObj.FsTaskState._stop_time;
-    var thedate = stop_time.substring(8, 10) + "-" + stop_time.substring(5, 7) + "-" + stop_time.substring(0, 4);
-    var FsTurnpoints = jsonObj.FsTaskDefinition.FsTurnpoint;
-    var FsStartGates = jsonObj.FsTaskDefinition.FsStartGate;
-
-    if (Array.isArray(FsStartGates)) {
-      ngates = FsStartGates.length;
+      jsonObj = { FsTask: tasks[taskN - 1] };
     }
 
-    if (ngates > 1 && FsStartGates.length > 1) {
-      var g1 = FsStartGates[1]._open.substring(11, 13) * 60 + FsStartGates[1]._open.substring(14, 16)
-      var g2 = FsStartGates[0]._open.substring(11, 13) * 60 + FsStartGates[0]._open.substring(14, 16)
-      gateint = g1 - g2;
-    }
+    var result = FsTask.parseTask(jsonObj, filename);
+    var jumpTheGun = Number(jsonObj.FsTask.FsScoreFormula._jump_the_gun_max);
+    var turnpointTollerance = Number(jsonObj.FsTask.FsScoreFormula._turnpoint_radius_tolerance);
 
-    for (let i = 0; i < FsTurnpoints.length; i++) {
-      var tp = {};
+    result.task.jumpTheGun = jumpTheGun;
+    result.task.turnpointTollerance = turnpointTollerance;
 
-      tp['index'] = i;
-      tp['radius'] = Number(FsTurnpoints[i]._radius);
-      tp['open'] = FsTurnpoints[i]._open.substring(11, 16);
-      tp['close'] = FsTurnpoints[i]._close.substring(11, 16);
-      tp['goalType'] = "cylinder";
-      tp['mode'] = "entry";
-
-      if (i == 0) {
-        tp['type'] = 'takeoff';
-      }
-      else if (i + 1 == ss) {
-        tp['type'] = 'start';
-      }
-      else if (i + 1 == es) {
-        tp['type'] = 'end-of-speed-section';
-      }
-      else if (i + 1 == FsTurnpoints.length) {
-        tp['type'] = 'goal';
-      }
-      else {
-        tp['type'] = 'turnpoint';
-      }
-
-      var wp = {
-        filename: filename,
-        id: FsTurnpoints[i]._id,
-        name: FsTurnpoints[i]._id,
-        type: 1,
-        x: FsTurnpoints[i]._lat,
-        y: FsTurnpoints[i]._lon,
-        z: FsTurnpoints[i]._altitude,
-      }
-      wps.push(wp);
-      tp.wp = wp;
-      tps.push(tp);
-    }
-
-    // console.log(JSON.stringify(tps, undefined, 2)) 
-    // console.log(JSON.stringify(wps, undefined, 2)) 
-
-    return {
-      'task': {
-        'date': thedate,
-        'type': 'race',
-        'num': taskN,
-        'ngates': ngates,
-        'gateint': gateint,
-        'turnpoints': tps,
-        'utcOffset': utc_offset,
-        'jumpTheGun': jumpTheGun,
-        'turnpointTollerance': turnpointTollerance,
-      },
-      'waypoints': wps,
-    }
+    return result;
   }
 
 
@@ -176,7 +105,7 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], 
     var tasks = jsonDB.Fs.FsCompetition.FsTasks.FsTask;
     var taskN = 0;
     if (tasks != undefined) {
-      if ( tasks.length == undefined ) {
+      if (tasks.length == undefined) {
         taskN = 1;
       }
       else {
@@ -229,7 +158,7 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], 
     }
 
     //var theDate = date.getUTCFullYear() + '-' + (date.getUTCMonth() + 1).pad(2) + '-' + day.pad(2)
-    var theDate = taskInfo.date.substring(6,10) + '-' +  taskInfo.date.substring(3,5) + '-' + taskInfo.date.substring(0,2)
+    var theDate = taskInfo.date.substring(6, 10) + '-' + taskInfo.date.substring(3, 5) + '-' + taskInfo.date.substring(0, 2)
 
     var data = exportFsTask({
       turnpoints: turnpoints,
@@ -252,7 +181,7 @@ define(['rejs!formats/export/FsTask', 'app/helper', 'jgrowl', 'xml-formatter'], 
       jsonDB.Fs.FsCompetition.FsTasks = empty;
     }
 
-    if (jsonDB.Fs.FsCompetition.FsTasks.FsTask.length == undefined ) {
+    if (jsonDB.Fs.FsCompetition.FsTasks.FsTask.length == undefined) {
       let t1 = jsonDB.Fs.FsCompetition.FsTasks.FsTask;
       let ar1 = new Array();
       ar1.push(t1);

--- a/js/app/formats/FsTask.js
+++ b/js/app/formats/FsTask.js
@@ -27,11 +27,13 @@ define(['rejs!formats/export/FsTask'], function (exportFsTask) {
 
     var ss = jsonObj.FsTask.FsTaskDefinition._ss;
     var es = jsonObj.FsTask.FsTaskDefinition._es;
-    var stop_time = jsonObj.FsTask.FsTaskState._stop_time;
-    var thedate = stop_time.substring(8, 10) + "-" + stop_time.substring(5, 7) + "-" + stop_time.substring(0, 4);
     var FsTurnpoints = jsonObj.FsTask.FsTaskDefinition.FsTurnpoint;
     var FsStartGates = jsonObj.FsTask.FsTaskDefinition.FsStartGate;
-    var c = 15;
+    var dateString = FsTurnpoints[0]._open
+    var thedate = dateString.substring(8, 10) + "-" + dateString.substring(5, 7) + "-" + dateString.substring(0, 4);
+    var day = Number(thedate.split('-')[0]);
+    var turn = (day % 2 == 0) ? 'right' : 'left';
+
     if (FsStartGates.length > 1) {
       let g1 = FsStartGates[1]._open.substring(11, 13) * 60 + FsStartGates[1]._open.substring(14, 16)
       let g2 = FsStartGates[0]._open.substring(11, 13) * 60 + FsStartGates[0]._open.substring(14, 16)
@@ -88,6 +90,7 @@ define(['rejs!formats/export/FsTask'], function (exportFsTask) {
         'num': 1,
         'ngates': FsStartGates.length,
         'gateint': gateint,
+        'turn': turn,
         'turnpoints': tps,
       },
       'waypoints': wps,
@@ -168,5 +171,6 @@ define(['rejs!formats/export/FsTask'], function (exportFsTask) {
     'extension': '.fstask',
     'name': 'FsTask',
     'parse': parse,
+    'parseTask': parseTask,
   }
 });

--- a/js/app/formats/tsk.js
+++ b/js/app/formats/tsk.js
@@ -20,6 +20,10 @@ define(['rejs!formats/export/tsk'], function(exportTSK) {
     var tps = [];
     var wps = [];
     var array = ['close', 'goalType', 'index', 'mode', 'open', 'radius', 'type'];
+
+    var date = xmlDoc.getElementsByTagName('date')[0].childNodes[0] ? xmlDoc.getElementsByTagName('date')[0].childNodes[0].nodeValue : 0;
+    var day = Number(date.split('-')[0]);
+    var turn = (day % 2 == 0) ? 'right' : 'left';
     
     for (var i = 0; i < rtetp.length; i++) {
       var tp = {};
@@ -78,6 +82,7 @@ define(['rejs!formats/export/tsk'], function(exportTSK) {
         'num' : xmlDoc.getElementsByTagName('num')[0].childNodes[0].nodeValue,
         'ngates' : xmlDoc.getElementsByTagName('ngates')[0].childNodes[0].nodeValue,
         'gateint' : xmlDoc.getElementsByTagName('gateint')[0].childNodes[0].nodeValue,
+        'turn' : turn,
         'info' : tinfo,
         'turnpoints' : tps,
       },

--- a/js/app/param.js
+++ b/js/app/param.js
@@ -12,8 +12,7 @@ define([], function () {
 
   var date = new Date();
   var day = date.getUTCDate();
-  //var turn = (day % 2 == 0) ? 'right' : 'left';
-  var turn = 'left';
+  var turn = (day % 2 == 0) ? 'right' : 'left';
 
   return {
     showCumulativeDistances: false,

--- a/js/app/task/task.js
+++ b/js/app/task/task.js
@@ -140,8 +140,6 @@ define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2',
       else {
         taskInfo.num--;
       }
-      taskInfo.turn = (taskInfo.num % 2 == 0) ? 'right' : 'left';
-
       taskChange();
     }
 
@@ -159,6 +157,8 @@ define(['task/taskBoard', 'task/turnpoint', 'task/fullBoard', 'task/fullBoard2',
     var onchangeTaskDate = function (e) {
       var date = e.detail.date;
       taskInfo.date = date;
+      var day = Number(date.substr(0, 2));
+      taskInfo.turn = (day % 2 == 0) ? 'right' : 'left';
       taskChange();
     }
 


### PR DESCRIPTION
By convenction, the turn direction before the start is defined by the task date, not by the task number: We turn left on odd days, and right on even days. This is generally known and used in competitions around the world. With  this change, we ensure that this is also the default in tasks defined in TaskCreator.